### PR TITLE
Add cleanlab as baseline method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ scikit-learn
 pyarrow
 tqdm
 scipy
+cleanlab==2.0.0
+scikit-learn-extra==0.2.0


### PR DESCRIPTION
Adds another baseline method that can be run, based on the cleanlab tool to detect data with low-quality labels:
https://github.com/cleanlab/cleanlab/

There are two options I added:

Option 1: cleanlab label quality score (chosen via `method='cleanlab'`).
This filters out data that cleanlab thinks have the lowest quality labels. Typically one would not filter so extremely with cleanlab, since it is intended primarily to only filter out the bad data as opposed to finding a good coreset as well.

Option 2: cleanlab for filtering bad data followed by K-medoids clustering to select coreset amongst remaining good data (chosen via `method='cleanlab_kmedoids'`)
This first filters out data that cleanlab thinks have the lowest quality labels.
Then applies K-medoids clustering to remaining good data to find a coreset.

Note if these options are running too slow for you with `NUM_FOLDS=10`, you can set it to 2 instead and still get similar numbers with a much faster run (I wasn't sure what are compute limits here).  I also hard-coded many things in this code such as the desired subsample size, as I'm not sure what is the official format for passing in such arguments to the baseline methods, since the example baseline method did not have args passed to it.

Here are the scores I got running eval.py:

From your example baseline method in the included code:  score = 0.750789054111216
From Option 1 with NUM_FOLDS=2:  score = 0.9023199817785442
From Option 2 with NUM_FOLDS=2:  score = 0.9772
From Option 2 with NUM_FOLDS=10:  score 0.9780366381414115

Note I didn't have time for any hyperparameter fiddling, so all values I chose are completely arbitrary and the performance of these new baselines can be easily improved. 