### PR TITLE
sort label ids lexicographically across train and eval in eval.py

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -48,7 +48,7 @@ def create_dataset(embeddings):
     Creates an sklearn-compatible dataset from an embedding dict
     """
     target_to_classid = {
-        target: ix + 1 for ix, target in enumerate(embeddings["targets"].keys())
+        target: ix + 1 for ix, target in enumerate(sorted(embeddings["targets"].keys()))
     }
     target_to_classid["nontarget"] = 0
 
@@ -129,7 +129,7 @@ def main(
     pred_y = clf.predict(eval_x)
 
     print("Score: ", balanced_accuracy_score(eval_y, pred_y))
-    
+
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/selection/main.py
+++ b/selection/main.py
@@ -96,7 +96,7 @@ def main(
             dict(targets=train.targets, nontargets=train.nontargets),
             fh,
             default_flow_style=None,
-            sort_keys=False,
+            sort_keys=True,
         )
 
 


### PR DESCRIPTION
the change containing the bugfix is located only in `eval.py` 

sorting is not necessary during training, but makes for easier comparison against eval.py if someone wanted to compare models produced by both scripts

this PR also adds a parameter to control the balance between the number of target and nontarget samples in our baseline k-fold implementation (I have not swept the balance to see what is best, just chose 60% target for now)

the following `train.yaml`  scores `0.917` in `eval.py` (during selection the score estimate was `0.883`)

```yaml
nontargets: [facing/common_voice_en_18323086.wav, tomorrow/common_voice_en_18497031.wav,
  item/common_voice_en_19816445.wav, win/common_voice_en_18484847.wav, increases/common_voice_en_19699563.wav,
  forced/common_voice_en_120909.wav, sits/common_voice_en_20638069.wav, defense/common_voice_en_18680475.wav,
  seconds/common_voice_en_126919.wav, grand/common_voice_en_18734048.wav, vice/common_voice_en_18827601.wav,
  everyone/common_voice_en_156986.wav, certainly/common_voice_en_159584.wav, seconds/common_voice_en_35287.wav,
  bush/common_voice_en_18339777.wav, child/common_voice_en_18844765.wav, allen/common_voice_en_19002827.wav,
  forever/common_voice_en_142303.wav, journey/common_voice_en_19769331.wav, vision/common_voice_en_17288951.wav,
  grief/common_voice_en_17936300.wav, ear/common_voice_en_19239345.wav, everyone/common_voice_en_16236.wav,
  matters/common_voice_en_18665156.wav, arts/common_voice_en_18199594.wav, forever/common_voice_en_14978893.wav,
  dead/common_voice_en_1617153.wav, facing/common_voice_en_20093091.wav, flung/common_voice_en_152120.wav,
  called/common_voice_en_19974269.wav, grand/common_voice_en_19153733.wav, vice/common_voice_en_19312763.wav,
  have/common_voice_en_17414116.wav, challenges/common_voice_en_20690016.wav, each/common_voice_en_19637832.wav,
  ocean/common_voice_en_162632.wav, closely/common_voice_en_17245943.wav, fatima/common_voice_en_522860.wav,
  six/common_voice_en_21721840.wav, item/common_voice_en_18594995.wav, venom/common_voice_en_431580.wav,
  seconds/common_voice_en_18143497.wav, municipality/common_voice_en_19098104.wav,
  tribal/common_voice_en_190814.wav, grand/common_voice_en_20090957.wav, someday/common_voice_en_18944237.wav,
  six/common_voice_en_20792980.wav, tasted/common_voice_en_122947.wav]
targets:
  episode: [episode/common_voice_en_19649204.wav, episode/common_voice_en_18734112.wav,
    episode/common_voice_en_21602061.wav, episode/common_voice_en_21231117.wav, episode/common_voice_en_19534598.wav,
    episode/common_voice_en_20836381.wav, episode/common_voice_en_20924278.wav, episode/common_voice_en_20583861.wav,
    episode/common_voice_en_19231381.wav, episode/common_voice_en_19869768.wav]
  fifty: [fifty/common_voice_en_556682.wav, fifty/common_voice_en_58134.wav, fifty/common_voice_en_18314980.wav,
    fifty/common_voice_en_682190.wav, fifty/common_voice_en_207639.wav, fifty/common_voice_en_20400820.wav,
    fifty/common_voice_en_535747.wav, fifty/common_voice_en_70136.wav, fifty/common_voice_en_20984024.wav,
    fifty/common_voice_en_692067.wav, fifty/common_voice_en_18508052.wav, fifty/common_voice_en_18350689.wav,
    fifty/common_voice_en_20243910.wav, fifty/common_voice_en_654833.wav, fifty/common_voice_en_676546.wav]
  job: [job/common_voice_en_17969626.wav, job/common_voice_en_17444685.wav, job/common_voice_en_484302.wav,
    job/common_voice_en_20748391.wav, job/common_voice_en_85686.wav, job/common_voice_en_17393053.wav,
    job/common_voice_en_461039.wav, job/common_voice_en_527088.wav, job/common_voice_en_82778.wav,
    job/common_voice_en_532396.wav, job/common_voice_en_576759.wav, job/common_voice_en_19827287.wav,
    job/common_voice_en_9595.wav, job/common_voice_en_609248.wav, job/common_voice_en_67281.wav,
    job/common_voice_en_93239.wav, job/common_voice_en_21972614.wav, job/common_voice_en_20792973.wav,
    job/common_voice_en_20239268.wav, job/common_voice_en_275175.wav, job/common_voice_en_20051941.wav,
    job/common_voice_en_17388021.wav, job/common_voice_en_415829.wav]
  restaurant: [restaurant/common_voice_en_645147.wav, restaurant/common_voice_en_185461.wav,
    restaurant/common_voice_en_87161.wav, restaurant/common_voice_en_19273946.wav,
    restaurant/common_voice_en_50717.wav, restaurant/common_voice_en_572873.wav, restaurant/common_voice_en_22346426.wav,
    restaurant/common_voice_en_691545.wav, restaurant/common_voice_en_18901987.wav,
    restaurant/common_voice_en_528411.wav, restaurant/common_voice_en_677312.wav,
    restaurant/common_voice_en_543540.wav]
  route: [route/common_voice_en_22364728.wav, route/common_voice_en_22328193.wav,
    route/common_voice_en_19993557.wav, route/common_voice_en_19719490.wav, route/common_voice_en_19497428.wav,
    route/common_voice_en_20188271.wav, route/common_voice_en_22095812.wav, route/common_voice_en_20294485.wav,
    route/common_voice_en_20056225.wav, route/common_voice_en_573504.wav, route/common_voice_en_19950575.wav,
    route/common_voice_en_19600096.wav]
```
