### PR TITLE
replace train.json -> train.yaml in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python -m selection.main \
   --outdir workspace/
 ```
 
-This will write out `train.yaml` into the directory specified by `--outdir` (which can be the same `workspace/` directory).
+This will write out `train.json` into the directory specified by `--outdir` (which can be the same `workspace/` directory).
 
 To evaluate your training set run:
 
@@ -89,7 +89,7 @@ python eval.py \
   --train_embeddings_dir workspace/train_embeddings/ \
   --allowed_training_set workspace/allowed_training_set.yaml \
   --eval_file workspace/eval.yaml \
-  --train_file workspace/train.yaml \
+  --train_file workspace/train.json \
   --config_file workspace/dataperf_speech_config.yaml
 
 ```


### PR DESCRIPTION
Not sure why running `python -m selection.main` returned `train.json` for me instead of `train.yaml`.

It's a bit strange to me because the eval.py code still seems to use `eval.yaml` not `eval.json`