### PR TITLE
Update cleanlab selection baseline for balanced_accuracy evaluation

### DIFF
--- a/selection/implementations/cleanlab_selection.py
+++ b/selection/implementations/cleanlab_selection.py
@@ -16,15 +16,30 @@ from sklearn_extra.cluster import KMedoids
 from selection.selection import TrainingSetSelection, TrainingSet
 
 
-class CleanlabsSelection(TrainingSetSelection):
+class CleanlabSelection(TrainingSetSelection):
     def __init__(self, **kwargs) -> None:
-        super(CleanlabsSelection, self).__init__(**kwargs)
+        super(CleanlabSelection, self).__init__(**kwargs)
 
     def select(self):
         """"
         Returns: 
             TrainingSet
         """
+        # Hyperparameters of this approach:
+        NUM_FOLDS = 10  # can significantly speed up code by decreasing this to 2
+        EXTRA_FRAC = 0.5  # what fraction of datapoints to delete with lowest cleanlab label quality scores (beyond default cleanlab filter)
+
+        SUBSET_SIZE = self.train_set_size
+        SEED = self.random_seed
+
+        clf = sklearn.ensemble.VotingClassifier(
+                    estimators=[
+                        ("svm", sklearn.svm.SVC(probability=True)),
+                        ("lr", sklearn.linear_model.LogisticRegression()),
+                    ],
+                    voting="soft",
+                    weights=None,
+                )
 
         if self.audio_flag:
             print(self.embeddings["nontargets"][0]["audio"])
@@ -35,7 +50,8 @@ class CleanlabsSelection(TrainingSetSelection):
         }
         target_to_classid["nontarget"] = 0
 
-        per_class_size = self.train_set_size // len(target_to_classid.keys())
+        num_classes = len(self.embeddings['targets'].keys()) + 1 #num targets + one non-target class
+        per_class_size = self.train_set_size // num_classes
 
         target_samples = np.array(
             [
@@ -65,20 +81,11 @@ class CleanlabsSelection(TrainingSetSelection):
         nontarget_labels = np.zeros(nontarget_samples.shape[0])
 
         
-        print("Using cleanlab and then K-medoids clustering to select data subset ...")
-        SEED = 123
-        NUM_FOLDS = 10  # can significantly speed up code by decreasing this to 2
-        SUBSET_SIZE = 120
-        CLEANLAB_FRAC = 0.5  # what fraction of datapoints to delete with lowest cleanlab scores (beyond default cleanlab filter)
-        clf = sklearn.ensemble.VotingClassifier(
-                    estimators=[
-                        ("svm", sklearn.svm.SVC(probability=True)),
-                        ("lr", sklearn.linear_model.LogisticRegression()),
-                    ],
-                    voting="soft",
-                    weights=None,
-                )
-        cl = cleanlab.classification.CleanLearning(clf, seed=SEED, verbose=True, cv_n_folds=NUM_FOLDS)
+        print("Using cleanlab + K-medoids clustering to select data subset ...")
+        cl = cleanlab.classification.CleanLearning(
+            clf, seed=SEED, verbose=True, cv_n_folds=NUM_FOLDS,
+            label_quality_scores_kwargs={"adjust_pred_probs": True}
+        )
         Xs = np.vstack(
                     [
                         target_samples,
@@ -94,23 +101,42 @@ class CleanlabsSelection(TrainingSetSelection):
         ys = ys.astype(int)
         issues = cl.find_label_issues(Xs, ys)
         bad_indices_filter = np.where(issues['is_label_issue'])[0]
-        num_delete_cleanlab = int(CLEANLAB_FRAC * len(ys))
-        bad_indices_rank = issues['label_quality'].values.argsort()[:num_delete_cleanlab]
-        bad_indices = np.unique(np.concatenate((bad_indices_filter,bad_indices_rank),0))
+        if EXTRA_FRAC > 0:
+            num_delete_cleanlab = int(EXTRA_FRAC * len(ys))
+            bad_indices_rank = issues['label_quality'].values.argsort()[:num_delete_cleanlab]
+            bad_indices = np.unique(np.concatenate((bad_indices_filter,bad_indices_rank),0))
+        else:
+            bad_indices = bad_indices_filter
         issues.drop(bad_indices, axis=0, inplace=True)
         inds_to_keep = issues.index.values
 
         # Cluster remaining data:
-        big_labels = ys[inds_to_keep,np.newaxis] * 1000  # multiply labels by large value to ensure clustering is label-aware:
-        data_to_cluster = np.concatenate([Xs[inds_to_keep], big_labels], axis=1)
-        # clstr = sklearn.cluster.KMeans(n_clusters=SUBSET_SIZE)
-        # cluster_ids = clstr.fit_predict(data_to_cluster)
-        clstr = KMedoids(n_clusters=SUBSET_SIZE, init="k-medoids++")
-        clstr.fit(data_to_cluster)
-        coreset_inds = clstr.medoid_indices_
+        og_ys = ys
+        ys = ys[inds_to_keep]
+        Xs = Xs[inds_to_keep]
+        # print("Class distribution: ")
+        # unique, counts = np.unique(ys, return_counts=True)
+        # print(np.asarray((unique, counts)).T)
+        # print("Finding coresets among remaining clean data ...")
+        best_indices = np.array([], dtype=int)
+        for y in np.unique(ys):
+            y_inds_to_keep = np.where(ys == y)[0]
+            Xs_y = Xs[y_inds_to_keep]
+            # can try Kmeans instead also:
+            # clstr = sklearn.cluster.KMeans(n_clusters=SUBSET_SIZE)
+            # cluster_ids = clstr.fit_predict(data_to_cluster)
+            clstr = KMedoids(n_clusters=per_class_size, init="k-medoids++")
+            clstr.fit(Xs_y)
+            coreset_y_inds = clstr.medoid_indices_
+            best_indices = np.concatenate((best_indices, inds_to_keep[y_inds_to_keep[coreset_y_inds]]))
         
+        # print("Class distribution post-selection: ")
+        # print(best_indices)
+        # unique, counts = np.unique(og_ys[best_indices], return_counts=True)
+        # print(np.asarray((unique, counts)).T)
+        print(len(best_indices))
+
         # Extract indices:
-        best_indices = inds_to_keep[coreset_inds]
         best_target_train_ixs = [x for x in best_indices if x < len(target_samples)]
         best_nontarget_train_ixs = [x-len(target_samples) for x in best_indices if x >= len(target_samples)]
 


### PR DESCRIPTION
Updates cleanlab selection baseline approach to reflect the fact that balanced_accuracy is now the evaluation metric for this competition.

Without having tinkered much with this baseline, eval.py produces baseline_accuracy Score: 0.9325

With proper tuning of its configurations, I assume this baseline can achieve a score of at least 0.94.