### PR TITLE
adding support for multiple languages

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -80,13 +80,29 @@ def create_dataset(embeddings):
 
 
 def main(
-    eval_embeddings_dir="embeddings/en",  # embeddings dir point to the same parquet file for testing and online eval
-    train_embeddings_dir="embeddings/en",
-    allowed_training_set="allowed_training_set.yaml",
-    eval_file="eval.yaml",
-    train_file="workdir/train.json",
-    config_file="dataperf_speech_config.yaml",
+    language="en",
+    eval_embeddings_dir=None,  # embeddings dir point to the same parquet file for testing and online eval
+    train_embeddings_dir=None,
+    allowed_training_set=None,
+    eval_file=None,
+    train_file=None,
+    config_file="workspace/dataperf_speech_config.yaml",
 ):
+
+    if eval_embeddings_dir is None:
+        eval_embeddings_dir = f"workspace/data/dataperf_{language}_data/eval_embeddings"
+
+    if train_embeddings_dir is None:
+        train_embeddings_dir = f"workspace/data/dataperf_{language}_data/train_embeddings"
+
+    if allowed_training_set is None:
+        allowed_training_set = f"workspace/data/dataperf_{language}_data/allowed_training_set.yaml"
+
+    if eval_file is None:
+        eval_file = f"workspace/data/dataperf_{language}_data/eval.yaml"
+
+    if train_file is None:
+        train_file = f"workspace/{language}_train.json"
 
     config = yaml.safe_load(Path(config_file).read_text())
     train_set_size_limit = config["train_set_size_limit"]

--- a/mlcube.py
+++ b/mlcube.py
@@ -28,6 +28,7 @@ class SelectTask:
     def run(config_file: str, allowed_training_set: str, train_embeddings_dir: str, outdir: str) -> None:
 
         cmd = "python3 -m selection.main"
+        cmd += f" --language en"
         cmd += f" --config_file {config_file}"
         cmd += f" --allowed_training_set {allowed_training_set}"
         cmd += f" --train_embeddings_dir {train_embeddings_dir}"
@@ -42,10 +43,11 @@ class EvaluateTask:
     """Execute evaluation script"""
 
     @staticmethod
-    def run(eval_embeddings_dir: str, train_embeddings_dir: str, allowed_training_set: str, eval_file: str, train_file: str, config_file: str, log_path: str) -> None:
+    def run( eval_embeddings_dir: str, train_embeddings_dir: str, allowed_training_set: str, eval_file: str, train_file: str, config_file: str, log_path: str) -> None:
 
         env = os.environ.copy()
         env.update({
+            'language': 'en',
             'eval_embeddings_dir': eval_embeddings_dir,
             'train_embeddings_dir': train_embeddings_dir,
             'allowed_training_set': allowed_training_set,

--- a/mlcube.yaml
+++ b/mlcube.yaml
@@ -27,8 +27,8 @@ tasks:
       inputs:
         {
           config_file: { type: file, default: dataperf_speech_config.yaml },
-          allowed_training_set: { type: file, default: data/preliminary_evaluation_dataset/allowed_training_set.yaml },
-          train_embeddings_dir: data/preliminary_evaluation_dataset/train_embeddings/,
+          allowed_training_set: { type: file, default: data/dataperf_en_data/allowed_training_set.yaml },
+          train_embeddings_dir: data/dataperf_en_data/train_embeddings/,
         }
       outputs: { outdir: select_output/ }
 
@@ -37,11 +37,11 @@ tasks:
     parameters:
       inputs:
         {
-          eval_embeddings_dir: data/preliminary_evaluation_dataset/eval_embeddings/,
-          train_embeddings_dir: data/preliminary_evaluation_dataset/train_embeddings/,
-          allowed_training_set: { type: file, default: data/preliminary_evaluation_dataset/allowed_training_set.yaml },
-          eval_file: { type: file, default: data/preliminary_evaluation_dataset/eval.yaml },
-          train_file: { type: file, default: select_output/train.json },
+          eval_embeddings_dir: data/dataperf_en_data/eval_embeddings/,
+          train_embeddings_dir: data/dataperf_en_data/train_embeddings/,
+          allowed_training_set: { type: file, default: data/dataperf_en_data/allowed_training_set.yaml },
+          eval_file: { type: file, default: data/dataperf_en_data/eval.yaml },
+          train_file: { type: file, default: select_output/en_train.json },
           config_file: { type: file, default: dataperf_speech_config.yaml },
         }
       outputs: { log_path: { type: file, default: log.txt } }

--- a/selection/main.py
+++ b/selection/main.py
@@ -14,17 +14,20 @@ from selection.selection import TrainingSetSelection
 
 
 def main(
-    allowed_training_set: os.PathLike,
-    train_embeddings_dir: os.PathLike = "/embeddings/en",
+    language: str = "en",
+    allowed_training_set: os.PathLike = None,
+    train_embeddings_dir: os.PathLike = None,
     audio_dir: Optional[os.PathLike] = None,
     config_file: os.PathLike = "workspace/dataperf_speech_config.yaml",
-    outdir: os.PathLike = "/workspace",
+    outdir: os.PathLike = "workspace",
 ):
     """
     Entrypoint for the training set selection algorithm. Challenge participants
     should *NOT MODIFY* main.py, and should instead modify selection.py (adding
     additional modules and dependencies is also fine, but the selection algorithm
     should be able to run offline without network access).
+
+    :param language: language of the training set selection, either "en", "id", or "pt"
 
     :param allowed_training_set: path to a yaml file containing the allowed clip
       IDs for training set selection, organized as a dictionary of potential target
@@ -45,6 +48,12 @@ def main(
     :param outdir: output directory to save the selected training set as a yaml file
 
     """
+
+    if train_embeddings_dir is None:
+        train_embeddings_dir = f"workspace/data/dataperf_{language}_data/train_embeddings"
+
+    if allowed_training_set is None:
+        allowed_training_set = f"workspace/data/dataperf_{language}_data/allowed_training_set.yaml"
 
     assert Path(
         outdir
@@ -91,7 +100,7 @@ def main(
         n_selected <= config["train_set_size_limit"]
     ), f"{n_selected} samples selected, but the limit is {config['train_set_size_limit']}"
 
-    output = Path(outdir) / "train.json"
+    output = Path(outdir) / f"{language}_train.json"
     output.write_text(
         json.dumps(
             dict(targets=train.targets, nontargets=train.nontargets),

--- a/utils/download_data.py
+++ b/utils/download_data.py
@@ -5,25 +5,19 @@ import yaml
 import wget
 import gdown
 import tarfile
-import zipfile
 
 
-def download_file(url, folder_path, extract=False, g_drive=False):
+def download_file(url, folder_path, file_name=None, extract=False, g_drive=False):
     """Download file from internet"""
-    if url:
-        if g_drive:
-            file_name = "preliminary_evaluation_dataset.zip"
-            output_path = os.path.join(folder_path, file_name)
-            gdown.download(url, output_path, quiet=False, fuzzy=True)
-            if extract:
-                with zipfile.ZipFile(output_path, 'r') as zip_ref:
-                    zip_ref.extractall(folder_path)
-        else:
-            output_path = wget.download(url, out=folder_path)
-            if extract:
-                tar = tarfile.open(output_path, "r:gz")
-                tar.extractall(folder_path)
-                tar.close()
+    if g_drive:
+        output_path = os.path.join(folder_path, file_name)
+        gdown.download(url, output_path, quiet=False, fuzzy=True)
+    else:
+        output_path = wget.download(url, out=folder_path)
+    if extract:
+        tar = tarfile.open(output_path, "r:gz")
+        tar.extractall(folder_path)
+        tar.close()
 
 
 def main():
@@ -49,9 +43,15 @@ def main():
         download_file(params["dataset_url"], output_path, extract=True)
     if "metadata_url" in params:
         download_file(params["metadata_url"], output_path)
-    if "embeddings_url" in params:
-        download_file(params["embeddings_url"], output_path, extract=True, g_drive=True)
-
+    if "en_embeddings_url" in params:
+        download_file(params["en_embeddings_url"], output_path, 
+            file_name="dataperf_en_data.tar.gz", extract=True, g_drive=True)
+    if "id_embeddings_url" in params:
+        download_file(params["id_embeddings_url"], output_path, 
+            file_name="dataperf_id_data.tar.gz", extract=True, g_drive=True)
+    if "pt_embeddings_url" in params:
+        download_file(params["pt_embeddings_url"], output_path, 
+            file_name="dataperf_pt_data.tar.gz", extract=True, g_drive=True)
 
 if __name__ == "__main__":
     main()

--- a/utils/run_evaluate.sh
+++ b/utils/run_evaluate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 python eval.py \
+  --language ${language} \
   --eval_embeddings_dir ${eval_embeddings_dir} \
   --train_embeddings_dir ${train_embeddings_dir} \
   --allowed_training_set ${allowed_training_set} \

--- a/workspace/parameters.yaml
+++ b/workspace/parameters.yaml
@@ -1,3 +1,6 @@
-metadata_url: "https://storage.googleapis.com/public-datasets-mswc/metadata.json.gz"
-embeddings_url: "https://drive.google.com/file/d/1Lj1l7-FxipKF6ZtVpy7nSRMEWMD2yfCd/view"
+# metadata_url: "https://storage.googleapis.com/public-datasets-mswc/metadata.json.gz"
+en_embeddings_url: "https://drive.google.com/uc?id=1aoOWzmxBCvSqaXEovTIYB1oaDySN44Ci"
+id_embeddings_url: "https://drive.google.com/uc?id=1wg0t2XXMOBTpEani9-2r1xOez57Weynl"
+pt_embeddings_url: "https://drive.google.com/uc?id=1hMt5jKA98hN6kv0gwOT-PBNGehYheYAo"
 # dataset_url: "https://storage.googleapis.com/public-datasets-mswc/mswc_microset.tar.gz"
+


### PR DESCRIPTION
Adds support for multiple languages (en, id, pt) by:

- changing the download process to download and extract data for 3 languages
- modify selection and eval to accept a language parameter
- update README

Note: Currently MLCube only works for english. This is because MLCube only allows parameters to be files. The MLCube workflow has been deprioritized so this isn't on the critical path for users.